### PR TITLE
Struct: toString/fromString

### DIFF
--- a/lib/struct.js
+++ b/lib/struct.js
@@ -46,11 +46,11 @@ class Struct {
   }
 
   toString() {
-    return Object.prototype.toString.call(this);
+    return JSON.stringify(this.toJSON());
   }
 
   fromString(str, extra) {
-    return this;
+    return this.fromJSON(JSON.parse(str), extra);
   }
 
   getJSON() {


### PR DESCRIPTION
I think `JSON.stringify/JSON.parse` will make better default for `toString/fromString`.

It will work better for most of the cases.
Inconsistency may occur, if someone implements one method but not another though. (e.g. toString only)