### PR TITLE
Add read/write for 128-bit and 256-bit BigInt values

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -701,6 +701,36 @@ function writeUBE(dst, num, off, len) {
   }
 }
 
+function writeBigU256BE(dst, num, off) {
+  // eslint-disable-next-line valid-typeof
+  enforce(typeof num === 'bigint', 'num', 'bigint');
+
+  num &= BITS_256_1S;
+
+  const hi = num >> BigInt(128);
+  const lo = num & BITS_128_1S;
+
+  off = writeBigU128BE(dst, hi, off);
+  off = writeBigU128BE(dst, lo, off);
+
+  return off;
+}
+
+function writeBigU128BE(dst, num, off) {
+  // eslint-disable-next-line valid-typeof
+  enforce(typeof num === 'bigint', 'num', 'bigint');
+
+  num &= BITS_128_1S;
+
+  const hi = num >> BigInt(64);
+  const lo = num & BITS_64_1S;
+
+  off = writeBigU64BE(dst, hi, off);
+  off = writeBigU64BE(dst, lo, off);
+
+  return off;
+}
+
 function writeBigU64BE(dst, num, off) {
   // eslint-disable-next-line valid-typeof
   enforce(typeof num === 'bigint', 'num', 'bigint');
@@ -1456,6 +1486,8 @@ exports.writeU16 = writeU16;
 exports.writeU8 = writeU8;
 
 exports.writeUBE = writeUBE;
+exports.writeBigU256BE = writeBigU256BE;
+exports.writeBigU128BE = writeBigU128BE;
 exports.writeBigU64BE = writeBigU64BE;
 exports.writeBigU56BE = writeBigU56BE;
 exports.writeU64BE = writeU64BE;

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -27,6 +27,10 @@ F32_ARRAY[0] = -1;
 
 const BIG_ENDIAN = F328_ARRAY[3] === 0;
 
+const BITS_64_1S = BigInt(2) ** BigInt(64) - 1n
+const BITS_128_1S = BigInt(2) ** BigInt(128) - 1n
+const BITS_256_1S = BigInt(2) ** BigInt(256) - 1n
+
 /*
  * Read Unsigned LE
  */
@@ -52,6 +56,20 @@ function readU(data, off, len) {
     default:
       throw new EncodingError(off, 'Invalid read length');
   }
+}
+
+function readBigU256(data, off) {
+  const hi = readBigU128(data, off + 16);
+  const lo = readBigU128(data, off);
+
+  return (BigInt(hi) << BigInt(128)) | BigInt(lo);
+}
+
+function readBigU128(data, off) {
+  const hi = readBigU64(data, off + 8);
+  const lo = readBigU64(data, off);
+
+  return (BigInt(hi) << BigInt(64)) | BigInt(lo);
 }
 
 function readBigU64(data, off) {
@@ -149,6 +167,20 @@ function readUBE(data, off, len) {
     default:
       throw new EncodingError(off, 'Invalid read length');
   }
+}
+
+function readBigU256BE(data, off) {
+  const hi = readBigU128BE(data, off);
+  const lo = readBigU128BE(data, off + 16);
+
+  return (BigInt(hi) << BigInt(128)) | BigInt(lo);
+}
+
+function readBigU128BE(data, off) {
+  const hi = readBigU64BE(data, off);
+  const lo = readBigU64BE(data, off + 8);
+
+  return (BigInt(hi) << BigInt(64)) | BigInt(lo);
 }
 
 function readBigU64BE(data, off) {
@@ -492,6 +524,36 @@ function writeU(dst, num, off, len) {
     default:
       throw new EncodingError(off, 'Invalid write length');
   }
+}
+
+function writeBigU256(dst, num, off) {
+  // eslint-disable-next-line valid-typeof
+  enforce(typeof num === 'bigint', 'num', 'bigint');
+
+  num &= BITS_256_1S;
+
+  const hi = num >> BigInt(128);
+  const lo = num & BITS_128_1S;
+
+  off = writeBigU128(dst, lo, off);
+  off = writeBigU128(dst, hi, off);
+
+  return off;
+}
+
+function writeBigU128(dst, num, off) {
+  // eslint-disable-next-line valid-typeof
+  enforce(typeof num === 'bigint', 'num', 'bigint');
+
+  num &= BITS_128_1S;
+
+  const hi = num >> BigInt(64);
+  const lo = num & BITS_64_1S;
+
+  off = writeBigU64(dst, lo, off);
+  off = writeBigU64(dst, hi, off);
+
+  return off;
 }
 
 function writeBigU64(dst, num, off) {
@@ -1325,6 +1387,8 @@ function check(value, offset, reason) {
  */
 
 exports.readU = readU;
+exports.readBigU256 = readBigU256;
+exports.readBigU128 = readBigU128;
 exports.readBigU64 = readBigU64;
 exports.readBigU56 = readBigU56;
 exports.readU64 = readU64;
@@ -1337,6 +1401,8 @@ exports.readU16 = readU16;
 exports.readU8 = readU8;
 
 exports.readUBE = readUBE;
+exports.readBigU256BE = readBigU256BE;
+exports.readBigU128BE = readBigU128BE;
 exports.readBigU64BE = readBigU64BE;
 exports.readBigU56BE = readBigU56BE;
 exports.readU64BE = readU64BE;
@@ -1376,6 +1442,8 @@ exports.readDouble = readDouble;
 exports.readDoubleBE = readDoubleBE;
 
 exports.writeU = writeU;
+exports.writeBigU256 = writeBigU256;
+exports.writeBigU128 = writeBigU128;
 exports.writeBigU64 = writeBigU64;
 exports.writeBigU56 = writeBigU56;
 exports.writeU64 = writeU64;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -460,6 +460,21 @@ class BufferReader {
   }
 
   /**
+   * Read uint128be as a BigInt.
+   * @returns {BigInt}
+   */
+
+  readBigU128BE() {
+    this.check(16);
+
+    const ret = encoding.readBigU128BE(this.data, this.offset);
+
+    this.offset += 16;
+
+    return ret;
+  }
+
+  /**
    * Read uint256le as a BigInt.
    * @returns {BigInt}
    */
@@ -468,6 +483,21 @@ class BufferReader {
     this.check(32);
 
     const ret = encoding.readBigU256(this.data, this.offset);
+
+    this.offset += 32;
+
+    return ret;
+  }
+
+  /**
+   * Read uint256be as a BigInt.
+   * @returns {BigInt}
+   */
+
+  readBigU256BE() {
+    this.check(32);
+
+    const ret = encoding.readBigU256BE(this.data, this.offset);
 
     this.offset += 32;
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -445,6 +445,36 @@ class BufferReader {
   }
 
   /**
+   * Read uint128le as a BigInt.
+   * @returns {BigInt}
+   */
+
+  readBigU128() {
+    this.check(16);
+
+    const ret = encoding.readBigU128(this.data, this.offset);
+
+    this.offset += 16;
+
+    return ret;
+  }
+
+  /**
+   * Read uint256le as a BigInt.
+   * @returns {BigInt}
+   */
+
+  readBigU256() {
+    this.check(32);
+
+    const ret = encoding.readBigU256(this.data, this.offset);
+
+    this.offset += 32;
+
+    return ret;
+  }
+
+  /**
    * Read int8.
    * @returns {Number}
    */

--- a/lib/staticwriter.js
+++ b/lib/staticwriter.js
@@ -388,6 +388,28 @@ class StaticWriter {
   }
 
   /**
+   * Write uint128le.
+   * @param {BigInt} value
+   */
+
+  writeBigU128(value) {
+    this.check(16);
+    this.offset = encoding.writeBigU128(this.data, value, this.offset);
+    return this;
+  }
+
+  /**
+   * Write uint256le.
+   * @param {BigInt} value
+   */
+
+  writeBigU256(value) {
+    this.check(32);
+    this.offset = encoding.writeBigU256(this.data, value, this.offset);
+    return this;
+  }
+
+  /**
    * Write int8.
    * @param {Number} value
    */

--- a/lib/staticwriter.js
+++ b/lib/staticwriter.js
@@ -399,6 +399,17 @@ class StaticWriter {
   }
 
   /**
+   * Write uint128be.
+   * @param {BigInt} value
+   */
+
+  writeBigU128BE(value) {
+    this.check(16);
+    this.offset = encoding.writeBigU128BE(this.data, value, this.offset);
+    return this;
+  }
+
+  /**
    * Write uint256le.
    * @param {BigInt} value
    */
@@ -406,6 +417,17 @@ class StaticWriter {
   writeBigU256(value) {
     this.check(32);
     this.offset = encoding.writeBigU256(this.data, value, this.offset);
+    return this;
+  }
+
+  /**
+   * Write uint256be.
+   * @param {BigInt} value
+   */
+
+  writeBigU256BE(value) {
+    this.check(32);
+    this.offset = encoding.writeBigU256BE(this.data, value, this.offset);
     return this;
   }
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -65,7 +65,9 @@ const BIG_I56BE = 46;
 const BIG_I64 = 47;
 const BIG_I64BE = 48;
 const BIG_U128 = 49;
-const BIG_U256 = 50;
+const BIG_U128BE = 50;
+const BIG_U256 = 51;
+const BIG_U256BE = 52;
 
 /**
  * Buffer Writer
@@ -245,8 +247,14 @@ class BufferWriter {
         case BIG_U128:
           off = encoding.writeBigU128(data, op.value, off);
           break;
+        case BIG_U128BE:
+          off = encoding.writeBigU128BE(data, op.value, off);
+          break;
         case BIG_U256:
           off = encoding.writeBigU256(data, op.value, off);
+          break;
+        case BIG_U256BE:
+          off = encoding.writeBigU256BE(data, op.value, off);
           break;
         default:
           throw new Error('Invalid type.');
@@ -518,6 +526,17 @@ class BufferWriter {
   }
 
   /**
+   * Write uint128be.
+   * @param {BigInt} value
+   */
+
+  writeBigU128BE(value) {
+    this.offset += 16;
+    this.ops.push(new BigOp(BIG_U128BE, value));
+    return this;
+  }
+
+  /**
    * Write uint256le.
    * @param {BigInt} value
    */
@@ -525,6 +544,17 @@ class BufferWriter {
   writeBigU256(value) {
     this.offset += 32;
     this.ops.push(new BigOp(BIG_U256, value));
+    return this;
+  }
+
+  /**
+   * Write uint256be.
+   * @param {BigInt} value
+   */
+
+  writeBigU256BE(value) {
+    this.offset += 32;
+    this.ops.push(new BigOp(BIG_U256BE, value));
     return this;
   }
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -64,6 +64,8 @@ const BIG_I56 = 45;
 const BIG_I56BE = 46;
 const BIG_I64 = 47;
 const BIG_I64BE = 48;
+const BIG_U128 = 49;
+const BIG_U256 = 50;
 
 /**
  * Buffer Writer
@@ -239,6 +241,12 @@ class BufferWriter {
           break;
         case BIG_I64BE:
           off = encoding.writeBigI64BE(data, op.value, off);
+          break;
+        case BIG_U128:
+          off = encoding.writeBigU128(data, op.value, off);
+          break;
+        case BIG_U256:
+          off = encoding.writeBigU256(data, op.value, off);
           break;
         default:
           throw new Error('Invalid type.');
@@ -495,6 +503,28 @@ class BufferWriter {
   writeBigU64BE(value) {
     this.offset += 8;
     this.ops.push(new BigOp(BIG_U64BE, value));
+    return this;
+  }
+
+  /**
+   * Write uint128le.
+   * @param {BigInt} value
+   */
+
+  writeBigU128(value) {
+    this.offset += 16;
+    this.ops.push(new BigOp(BIG_U128, value));
+    return this;
+  }
+
+  /**
+   * Write uint256le.
+   * @param {BigInt} value
+   */
+
+  writeBigU256(value) {
+    this.offset += 32;
+    this.ops.push(new BigOp(BIG_U256, value));
     return this;
   }
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -222,4 +222,26 @@ describe('bufio', function() {
       }
     });
   }
+
+  it('should write+read a 128 bit bigint little endian', () => {
+    const num = 2n ** 127n + 63542n
+
+    const buf = Buffer.allocUnsafe(16);
+
+    encoding.writeBigU128(buf, num, 0);
+
+    const n2 = encoding.readBigU128(buf, 0);
+    assert.strictEqual(num, n2);
+  })
+
+  it('should write+read a 256 bit bigint little endian', () => {
+    const num = 2n ** 127n + 63542n
+
+    const buf = Buffer.allocUnsafe(32);
+
+    encoding.writeBigU256(buf, num, 0);
+
+    const n2 = encoding.readBigU256(buf, 0);
+    assert.strictEqual(num, n2);
+  })
 });

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -234,14 +234,36 @@ describe('bufio', function() {
     assert.strictEqual(num, n2);
   })
 
+  it('should write+read a 128 bit bigint big endian', () => {
+    const num = 2n ** 127n + 43523n
+
+    const buf = Buffer.allocUnsafe(16);
+
+    encoding.writeBigU128BE(buf, num, 0);
+
+    const n2 = encoding.readBigU128BE(buf, 0);
+    assert.strictEqual(num, n2);
+  })
+
   it('should write+read a 256 bit bigint little endian', () => {
-    const num = 2n ** 127n + 63542n
+    const num = 2n ** 255n + 2348932n
 
     const buf = Buffer.allocUnsafe(32);
 
     encoding.writeBigU256(buf, num, 0);
 
     const n2 = encoding.readBigU256(buf, 0);
+    assert.strictEqual(num, n2);
+  })
+
+  it('should write+read a 256 bit bigint big endian', () => {
+    const num = 2n ** 255n + 454523n
+
+    const buf = Buffer.allocUnsafe(32);
+
+    encoding.writeBigU256BE(buf, num, 0);
+
+    const n2 = encoding.readBigU256BE(buf, 0);
     assert.strictEqual(num, n2);
   })
 });


### PR DESCRIPTION
Hey @chjj we are using your library and have some use cases for larger BigInt serialization. I've added this code to our codebase but wanted to contribute in case this was useful to others too. I've tried to follow coding conventions as I see them. Let me know if this is useful or if you have any other comments. Thanks!